### PR TITLE
Add include-on-hold option to treat on-hold workflows as running in queue

### DIFF
--- a/src/commands/block_execution.yml
+++ b/src/commands/block_execution.yml
@@ -25,6 +25,10 @@ parameters:
       Due to concurrency issues, how many times should we requery the pipeline list to ensure previous jobs are "pending",
       but not yet active. This number indicates the threshold for API returning no previous pending pipelines.
       Default is one confirmation, increase if you see issues.
+  include-on-hold:
+    type: boolean
+    default: false
+    description: Consider on-hold workflows waiting for approval as running and include them in the queue.
 
 steps:
   - run:
@@ -35,4 +39,5 @@ steps:
         CONFIG_DONT_QUIT: "<< parameters.dont-quit >>"
         CONFIG_ONLY_ON_BRANCH: "<< parameters.only-on-branch >>"
         CONFIG_CONFIDENCE: "<< parameters.confidence >>"
+        CONFIG_INCLUDE_ON_HOLD: " << parameters.include-on-hold >>"
       command: <<include(scripts/queue.sh)>>

--- a/src/jobs/queue.yml
+++ b/src/jobs/queue.yml
@@ -29,6 +29,10 @@ parameters:
       Due to concurrency issues, how many times should we requery the pipeline list to ensure previous jobs are "pending",
       but not yet active. This number indicates the threshold for API returning no previous pending pipelines.
       Default is one confirmation, increase if you see issues.
+  include-on-hold:
+    type: boolean
+    default: false
+    description: Consider on-hold workflows waiting for approval as running and include them in the queue.
 
 steps:
   - block_execution:
@@ -37,3 +41,4 @@ steps:
       dont-quit: <<parameters.dont-quit>>
       only-on-branch: <<parameters.only-on-branch>>
       confidence: <<parameters.confidence>>
+      include-on-hold: <<parameters.include-on-hold>>

--- a/src/scripts/queue.sh
+++ b/src/scripts/queue.sh
@@ -66,7 +66,12 @@ fetch_pipeline_workflows(){
         created_at=$(jq -r '.items[] | .created_at' "${pipeline_detail}")
         debug "Pipeline's workflow was created at: ${created_at}"
     done
-    jq -s '[.[].items[] | select((.status == "running") or (.status == "created"))]' ${tmp}/pipeline-*.json > ${workflows_file}
+    if [ "${CONFIG_INCLUDE_ON_HOLD}" == "1" ]; then
+        active_statuses='["running","created","on_hold"]'
+    else
+        active_statuses='["running","created"]'
+    fi
+    jq -s '[.[].items[] | select([.status] | inside('${active_statuses}'))]' ${tmp}/pipeline-*.json > ${workflows_file}
 }
 
 # parse workflows to fetch parmeters about this current running workflow

--- a/src/scripts/queue.sh
+++ b/src/scripts/queue.sh
@@ -66,12 +66,12 @@ fetch_pipeline_workflows(){
         created_at=$(jq -r '.items[] | .created_at' "${pipeline_detail}")
         debug "Pipeline's workflow was created at: ${created_at}"
     done
-    if [ "${CONFIG_INCLUDE_ON_HOLD}" == "1" ]; then
-        active_statuses='["running","created","on_hold"]'
+    if [ "${CONFIG_INCLUDE_ON_HOLD}" = "1" ]; then
+        active_statuses="$(printf '%s' '["running","created","on_hold"]')"
     else
-        active_statuses='["running","created"]'
+        active_statuses="$(printf '%s' '["running","created"]')"
     fi
-    jq -s '[.[].items[] | select([.status] | inside('${active_statuses}'))]' ${tmp}/pipeline-*.json > ${workflows_file}
+    jq -s "[.[].items[] | select([.status] | inside(${active_statuses}))]" ${tmp}/pipeline-*.json > ${workflows_file}
 }
 
 # parse workflows to fetch parmeters about this current running workflow

--- a/test_workflow.json
+++ b/test_workflow.json
@@ -1,0 +1,16 @@
+{
+  "next_page_token": null,
+  "items": [
+    {
+      "pipeline_id": "49287a8d-969e-4bba-850a-051f18078b2c",
+      "id": "574f4ff2-eadb-48ca-a082-8241c000d5bc",
+      "name": "workflow",
+      "project_slug": "gh/boxfortinc/level99-nimbus",
+      "status": "on_hold",
+      "started_by": "f471266e-c8b8-4237-8564-36e5537ad72d",
+      "pipeline_number": 1719,
+      "created_at": "2023-10-17T17:38:27Z",
+      "stopped_at": null
+    }
+  ]
+}


### PR DESCRIPTION
Manual approval jobs in CircleCI often are used to block workflows. This change prevents later workflows from running while a previous one is still on hold for manual approval.

For pipelines that just need to ensure jobs don't run concurrently and don't care what order workflows finish in, this option is by default set to false (the current behavior). 

