### PR TITLE
Update global-queue.yml example to use version 3

### DIFF
--- a/src/examples/global-queue.yml
+++ b/src/examples/global-queue.yml
@@ -3,11 +3,11 @@ description: >
 usage:
   version: 2.1
   orbs:
-    workflow-queue: promiseofcake/workflow-queue@2
+    workflow-queue: promiseofcake/workflow-queue@3
   workflows:
     example:
       jobs:
-        - workflow-queue/queue:
+        - workflow-queue/global-queue:
             name: workflow-queue
             context: <context-key>
             only-on-branch: main


### PR DESCRIPTION
The global-queue example is outdated (showing version 2 and the old "queue").

This PR updates the example to use v3.